### PR TITLE
feat: persistent monitoring notification, bottom sheet fix, version bump

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,5 +117,5 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.kuriamind
           releaseFiles: artifacts/kuriamind-aab-${{ steps.gradle_versions.outputs.version_name }}.aab
-          track: internal
+          tracks: internal
           status: draft

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.kuriamind"
         minSdk = 24
         targetSdk = 36
-        versionCode = 13
-        versionName = "1.1"
+        versionCode = 14
+        versionName = "1.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
@@ -51,6 +53,11 @@
                 android:name="android.accessibilityservice"
                 android:resource="@xml/app_monitor_service_config" />
         </service>
+
+        <service
+            android:name=".services.MonitoringService"
+            android:foregroundServiceType="specialUse"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/kuriamind/KuriamindApplication.kt
+++ b/app/src/main/java/com/kuriamind/KuriamindApplication.kt
@@ -2,10 +2,17 @@ package com.kuriamind
 
 import android.app.Application
 import android.content.Context
+import com.kuriamind.services.MonitoringService
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
 class KuriamindApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        MonitoringService.start(this)
+    }
+
 
     companion object {
         private const val PREFS_NAME = "kuriamind_prefs"

--- a/app/src/main/java/com/kuriamind/services/AppMonitorService.kt
+++ b/app/src/main/java/com/kuriamind/services/AppMonitorService.kt
@@ -20,6 +20,7 @@ import javax.inject.Inject
 class AppMonitorService : AccessibilityService() {
 
     @Inject lateinit var repository: BlockRepository
+    @Inject lateinit var blockedEventCounter: BlockedEventCounter
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var lastBlockedPackage = ""
@@ -53,6 +54,7 @@ class AppMonitorService : AccessibilityService() {
             Log.d(TAG, "BLOCKING $packageName (block: '${matchingBlock.name}')")
             lastBlockedPackage = packageName
             lastBlockedAt = SystemClock.uptimeMillis()
+            blockedEventCounter.increment()
 
             withContext(Dispatchers.Main) {
                 performGlobalAction(GLOBAL_ACTION_HOME)

--- a/app/src/main/java/com/kuriamind/services/BlockedEventCounter.kt
+++ b/app/src/main/java/com/kuriamind/services/BlockedEventCounter.kt
@@ -1,0 +1,22 @@
+package com.kuriamind.services
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BlockedEventCounter @Inject constructor() {
+
+    private val _count = MutableStateFlow(0)
+    val count: StateFlow<Int> = _count.asStateFlow()
+
+    fun increment() {
+        _count.value = _count.value + 1
+    }
+
+    fun reset() {
+        _count.value = 0
+    }
+}

--- a/app/src/main/java/com/kuriamind/services/MonitoringService.kt
+++ b/app/src/main/java/com/kuriamind/services/MonitoringService.kt
@@ -1,0 +1,152 @@
+package com.kuriamind.services
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.kuriamind.MainActivity
+import com.kuriamind.R
+import com.kuriamind.domain.repository.BlockRepository
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class MonitoringService : android.app.Service() {
+
+    @Inject lateinit var repository: BlockRepository
+    @Inject lateinit var blockedEventCounter: BlockedEventCounter
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var isForeground = false
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.d(TAG, "Service created")
+        createNotificationChannel()
+        startObserving()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.d(TAG, "onStartCommand: startId=$startId")
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun startObserving() {
+        scope.launch {
+            val activeCountFlow = repository.observeAll()
+                .map { blocks -> blocks.count { it.isActive } }
+                .distinctUntilChanged()
+
+            var wasActive = false
+
+            combine(
+                activeCountFlow,
+                blockedEventCounter.count,
+            ) { activeCount, blockedCount ->
+                activeCount to blockedCount
+            }.collect { (activeCount, blockedCount) ->
+                if (activeCount > 0 && !wasActive) {
+                    blockedEventCounter.reset()
+                    Log.d(TAG, "Monitoring started: $activeCount active block(s)")
+                }
+
+                wasActive = activeCount > 0
+
+                if (activeCount > 0) {
+                    Log.d(TAG, "Updating notification: active=$activeCount, blocked=$blockedCount")
+                    val notification = buildNotification(activeCount, blockedCount.coerceAtLeast(0))
+                    if (!isForeground) {
+                        try {
+                            startForeground(NOTIFICATION_ID, notification)
+                            isForeground = true
+                        } catch (e: SecurityException) {
+                            Log.e(TAG, "Missing notification permission", e)
+                        }
+                    } else {
+                        // Already foreground → just update the notification
+                        val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+                        manager.notify(NOTIFICATION_ID, notification)
+                    }
+                } else if (isForeground) {
+                    Log.d(TAG, "No active blocks, removing foreground notification")
+                    stopForeground(STOP_FOREGROUND_REMOVE)
+                    isForeground = false
+                }
+            }
+        }
+    }
+
+    private fun buildNotification(activeCount: Int, blockedCount: Int): Notification {
+        val openIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            openIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_app_icon)
+            .setContentTitle(getString(R.string.notification_monitoring_title))
+            .setContentText(
+                getString(R.string.notification_monitoring_content, activeCount, blockedCount)
+            )
+            .setStyle(
+                NotificationCompat.BigTextStyle()
+                    .bigText(
+                        getString(R.string.notification_monitoring_big_text, activeCount, blockedCount)
+                    )
+            )
+            .setContentIntent(pendingIntent)
+            .setOngoing(true)
+            .setSilent(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Monitoring",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = "Shows active monitoring status"
+        }
+        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.createNotificationChannel(channel)
+    }
+
+    override fun onDestroy() {
+        scope.cancel()
+        super.onDestroy()
+        Log.d(TAG, "Service destroyed")
+    }
+
+    companion object {
+        private const val TAG = "MonitoringService"
+        private const val CHANNEL_ID = "monitoring"
+        private const val NOTIFICATION_ID = 1001
+
+        fun start(context: Context) {
+            val intent = Intent(context, MonitoringService::class.java)
+            context.startService(intent)
+        }
+    }
+}

--- a/app/src/main/java/com/kuriamind/services/NotificationBlockerService.kt
+++ b/app/src/main/java/com/kuriamind/services/NotificationBlockerService.kt
@@ -17,6 +17,7 @@ import javax.inject.Inject
 class NotificationBlockerService : NotificationListenerService() {
 
     @Inject lateinit var repository: BlockRepository
+    @Inject lateinit var blockedEventCounter: BlockedEventCounter
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
@@ -48,6 +49,7 @@ class NotificationBlockerService : NotificationListenerService() {
             if (matchingBlock != null) {
                 Log.d(TAG, "CANCELLING notification from $packageName (matched block: '${matchingBlock.name}')")
                 cancelNotification(sbn.key)
+                blockedEventCounter.increment()
             } else {
                 Log.d(TAG, "No block matches $packageName notification, allowing")
             }

--- a/app/src/main/java/com/kuriamind/ui/feature/blocks/components/AppSelectorSheet.kt
+++ b/app/src/main/java/com/kuriamind/ui/feature/blocks/components/AppSelectorSheet.kt
@@ -44,9 +44,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -63,6 +67,21 @@ fun AppSelectorSheet(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var searchQuery by remember { mutableStateOf("") }
     var selected by remember { mutableStateOf(selectedPackages.toSet()) }
+
+    // Prevents infinite bounce when flinging LazyColumn to the bottom:
+    // consumes leftover overscroll so it never reaches the sheet's drag handler
+    val sheetNestedScrollConnection = remember {
+        object : NestedScrollConnection {
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource,
+            ): Offset {
+                if (available.y != 0f) return Offset(0f, available.y)
+                return Offset.Zero
+            }
+        }
+    }
 
     val filteredApps = remember(installedApps, searchQuery) {
         if (searchQuery.isBlank()) installedApps
@@ -82,7 +101,8 @@ fun AppSelectorSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .fillMaxHeight(0.9f)
-                .padding(horizontal = 20.dp),
+                .padding(horizontal = 20.dp)
+                .nestedScroll(sheetNestedScrollConnection),
         ) {
             // Header
             Row(

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -22,4 +22,9 @@
     <string name="next">Siguiente</string>
     <string name="start_app">Iniciar app</string>
 
+    <!-- Monitoring notification -->
+    <string name="notification_monitoring_title">Monitoreo</string>
+    <string name="notification_monitoring_content">Bloques activos: %1$d · Bloqueados: %2$d</string>
+    <string name="notification_monitoring_big_text">Bloques activos: %1$d\nBloqueados: %2$d</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,9 @@
     <string name="next">Next</string>
     <string name="start_app">Start App</string>
 
+    <!-- Monitoring notification -->
+    <string name="notification_monitoring_title">Monitoring</string>
+    <string name="notification_monitoring_content">Active blocks: %1$d · Blocked: %2$d</string>
+    <string name="notification_monitoring_big_text">Active blocks: %1$d\nBlocked: %2$d</string>
+
 </resources>


### PR DESCRIPTION
### Changes

#### 🆕 Persistent monitoring notification
- New `MonitoringService` — foreground service that shows a persistent notification when at least one block is active
- Shows "Active blocks" count and "Blocked" counter (notifications + apps blocked)
- Resets the blocked counter to 0 each time monitoring starts
- Self-promotes from background to foreground only when needed
- **i18n**: English + Spanish strings

#### 📊 Blocked event tracking
- New `BlockedEventCounter` (@Singleton with `StateFlow`) — shared counter across services
- `NotificationBlockerService` increments it on each notification cancelled
- `AppMonitorService` increments it on each app block

#### 🐛 Bottom sheet infinite bounce fix
- Added `NestedScrollConnection` to `AppSelectorSheet` that consumes leftover `LazyColumn` overscroll before it reaches the `ModalBottomSheet` drag handler
- Prevents infinite bounce loop when flinging to the bottom of the app list

#### 🔢 Version bump
- `versionCode`: 13 → 14
- `versionName`: 1.1 → 1.1.1